### PR TITLE
format number to have only 2 digits after decimal

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -356,6 +356,9 @@ td span {
   overflow: auto;
   width: 100%;
   height: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
 }
 
 .modal__table {
@@ -363,9 +366,17 @@ td span {
   border-collapse: collapse;
 }
 
+.modal__table.vertical {
+  align-self: flex-start;
+}
+
+.modal__table th {
+  white-space: nowrap;
+  padding: 5px;
+}
+
 .modal__table th,
 .modal__table td {
-  padding: 0 5px;
   border: 1px solid #000;
 }
 

--- a/assets/javascript/cfi.js
+++ b/assets/javascript/cfi.js
@@ -86,7 +86,7 @@ function switchCRS() {
   document.getElementById('espgCoordDOM').innerText = newCorrdinate.map(x => Number(x).toFixed(decimalsPos)).join(' ');
 }
 
-function getESPGToggleBtn(text, coordinateDOM) {
+function getESPGToggleBtn(text) {
   const btn = document.createElement('button');
   btn.innerHTML = text;
   btn.id = 'espgToggleBtn';
@@ -239,14 +239,13 @@ async function handleRelatedLayerClick(e) {
     return;
   }
 
-  const modalHeader = document.querySelector('#cfiModal .modal-header');
-  const headerText = document.createElement('strong');
-  headerText.innerText = layerName;
-  modalHeader.prepend(headerText);
+  const modalHeader = document.querySelector('#cfiModal .modal-header strong');
+  modalHeader.innerText = layerName;
 
   const table = document.querySelector('#cfiModal table');
   const tbody = document.createElement('tbody');
   table.innerHTML = '';
+  table.classList.remove('vertical');
 
   if (layerData.features.length > 1) {
     const thead = document.createElement('thead');
@@ -265,11 +264,18 @@ async function handleRelatedLayerClick(e) {
       const contents = Object.values(layer.properties);
       const tr = document.createElement('tr');
 
-      contents.forEach((item) => {
+      for (key in contents) {
+        const item = contents[key]
         const td = document.createElement('td');
-        td.append(item);
+
+        if (Utils.isNumeric(item) && !Utils.isCoordinate(key)) {
+          td.innerText = Number(item).toFixed(2);
+        } else {
+          td.append(item);
+        }
+
         tr.append(td);
-      });
+      }
 
       tbody.append(tr);
     });
@@ -279,6 +285,7 @@ async function handleRelatedLayerClick(e) {
   } else {
     const contentObj = layerData.features[0].properties;
     tbody.style.textAlign = 'left';
+    table.classList.add('vertical');
 
     for (key in contentObj) {
       const tr = document.createElement('tr');
@@ -288,7 +295,12 @@ async function handleRelatedLayerClick(e) {
       tdKey.innerText = TRANSLATE[key] || key;
       tr.append(tdKey);
 
-      tdVal.innerText = contentObj[key];
+      if (Utils.isNumeric(contentObj[key]) && !Utils.isCoordinate(key)) {
+        tdVal.innerText = Number(contentObj[key]).toFixed(2);
+      } else {
+        tdVal.innerText = contentObj[key];
+      }
+
       tr.append(tdVal);
 
       tbody.append(tr);
@@ -420,15 +432,11 @@ async function showCFI_B(data, defaultCrs) {
   } = data.feature.properties;
   const tbody = document.createElement('tbody');
 
-
-
   // careful about changing key
   // change the listener as well
   cfi_b['coordinate_system'] = (espg && espg.name) || I18n.translate('no_data');
   cfi_b['referencing_coordinate'] = `${x_coordinate} ${y_coordinate}`;
   cfi_b['in_province'] = data.feature.properties[I18n.translate({ en: 'province_en', kh: 'province' })];
-
-  console.log(data.feature);
 
   for (const key in cfi_b) {
     const tr = document.createElement('tr');
@@ -449,6 +457,8 @@ async function showCFI_B(data, defaultCrs) {
 
       if (x instanceof Element) {
         td.append(x);
+      } else if (Utils.isNumeric(x)) {
+        td.innerText = Number(x).toFixed(2);
       } else {
         td.innerText = x;
       }

--- a/assets/javascript/cfr.js
+++ b/assets/javascript/cfr.js
@@ -197,12 +197,20 @@ async function showCFR_A(data) {
       cfi_b[key] = Utils.formatDate(cfi_b[key]);
     }
 
-    [I18n.translate(key), cfi_b[key]].forEach((x, i) => {
+    [key, cfi_b[key]].forEach((x, i) => {
       const td = document.createElement('td');
-      td.innerText = x;
 
-      if (i > 0 && !x) {
-        td.innerText = I18n.translate('no_data');
+      if (i > 0) {
+        td.innerText = x;
+
+        if (!x) {
+          td.innerText = I18n.translate('no_data');
+        } else if (Utils.isNumeric(x) && !Utils.isCoordinate(x)) {
+          const str = typeof x === 'string' ? x.replace(',', '') : x;
+          td.innerText = Number(str).toFixed(2);
+        }
+      } else {
+        td.innerText = I18n.translate(x);
       }
 
       tr.append(td);

--- a/assets/javascript/utils.js
+++ b/assets/javascript/utils.js
@@ -135,6 +135,28 @@ const Utils = {
     const year = d.getFullYear();
 
     return day + separator + (I18n.translate(month)) + separator + year;
+  },
+  isNumeric: function (str) {
+    if (typeof str === 'string' && str[0] === '0' && (str[1] !== '.' || str[1] !== ',')) {
+      return false;
+    }
+
+    return /^-?[0-9][0-9,\.]+$/.test(str);
+  },
+  isCoordinate: function (key) {
+    const hashs = {
+      'x_coord': 1,
+      'y_coord': 1,
+      'lat': 1,
+      'long': 1,
+      'latitude': 1,
+      'longtitude': 1,
+      '_cfr_geopoint_latitude': 1,
+      '_cfr_geopoint_longitude': 1,
+      '_cfr_geopoint_altitude': 1,
+      '_cfr_geopoint_precision': 1,
+    };
+    return hashs[key] !== undefined;
   }
 };
 
@@ -159,12 +181,12 @@ const CustomCharts = {
     pieHeader.style.textAlign = 'center';
     pieHeader.style.color = '#2f4f4f';
     pieHeader.style.paddingTop = '5px';
-    
+
     const canvas = document.getElementById(selectorId);
     canvas.parentNode.insertBefore(pieHeader, canvas);
     canvas.style.paddingBottom = '10px';
     canvas.style.borderBottom = '1px dashed #000';
-    
+
     return new Chart(canvas, { type: 'pie', data: pieData });
   },
   barChart: function (selectorId) {

--- a/page/map_cfi.html
+++ b/page/map_cfi.html
@@ -97,7 +97,10 @@
 
     <div id="cfiModal" class="modal">
         <div class="modal-content">
-            <div class="modal-header"> <span class="close">&times;</span> </div>
+            <div class="modal-header">
+                <strong></strong>
+                <span class="close">&times;</span>
+            </div>
             <div class="modal__table__wrapper">
                 <table style="width: 98%;" class="modal__table">
                 </table>


### PR DESCRIPTION
# Details
Fix number format to allow only 2 digits after decimals
except for coordinates and lat, lng properties

## Related
resolves #22 

# Screenshot
![image](https://github.com/ODCambodia/cfi-data-portal/assets/45927893/0c4f5ebf-aeb9-4b58-b961-5ae375e91d52)

