### PR TITLE
hide demography header when no data

### DIFF
--- a/assets/javascript/cfi.js
+++ b/assets/javascript/cfi.js
@@ -233,10 +233,10 @@ const DemoGraphyChart = (function () {
 
     const chartData = response.features[0].properties;
 
-    loadHeader();
     loadChart(chartData, CHARTS_CONF.committee);
     loadChart(chartData, CHARTS_CONF.member);
     loadChart(chartData, CHARTS_CONF.population);
+    loadHeader();
   }
 
   return {


### PR DESCRIPTION
# Details
Hide demography when no chart is present
Fix by calling loadHeader() after all of the charts has loaded and check if they exists

# Related Issue
resolves #39 