### PR TITLE
Fully remove chart when demography data is empty

### DIFF
--- a/assets/javascript/cfi.js
+++ b/assets/javascript/cfi.js
@@ -244,6 +244,10 @@ const DemoGraphyChart = (function () {
     });
 
     if (!response.features.length > 0) {
+      $(`#${CHARTS_CONF.committee.id}`).remove();
+      $(`#${CHARTS_CONF.member.id}`).remove();
+      $(`#${CHARTS_CONF.population.id}`).remove();
+
       return;
     }
 

--- a/assets/javascript/cfr.js
+++ b/assets/javascript/cfr.js
@@ -128,11 +128,13 @@ const DemoGraphyChart = (function () {
     });
 
     if (!response.features.length > 0) {
+      $(`#${CHARTS_CONF.committee.id}`).remove();
+      $(`#${CHARTS_CONF.population.id}`).remove();
+
       return;
     }
 
     const chartData = response.features[0].properties;
-    console.log(chartData);
 
     loadChart(chartData, CHARTS_CONF.committee);
     loadChart(chartData, CHARTS_CONF.population);


### PR DESCRIPTION
# Details
remove chart dom when fetching demography layer fails 
# Related Issue
fix #57 
# Screenshot
![image](https://github.com/ODCambodia/cfi-data-portal/assets/45927893/01710ff1-4ca1-4454-bd2f-bd95992b7cb9)
