### PR TITLE
[IMP] Fix related document popup modal not display

### DIFF
--- a/assets/javascript/cfr.js
+++ b/assets/javascript/cfr.js
@@ -174,10 +174,10 @@ async function handleRelatedLayerClick(e) {
     return;
   }
 
-  const modalHeader = $('#cfrModal .modal-header strong');
+  const modalHeader = document.querySelector('#cfrModal .modal-header strong');
   modalHeader.innerText = layerName;
 
-  const table = $('#cfrModal table');
+  const table = document.querySelector('#cfrModal table');
   const tbody = document.createElement('tbody');
   table.innerHTML = '';
   table.classList.remove('vertical');


### PR DESCRIPTION
Fixed issue #71 

Change element selector from `$` to `document.querySelector`

It seems that the jQuery is not available.